### PR TITLE
Added direct links to posts and new share functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-device-detect": "^1.14.0",
     "react-dom": "^16.13.1",
     "react-flip-numbers": "^3.0.5",
+    "react-helmet": "^6.1.0",
     "react-infinite-scroller": "^1.2.4",
     "react-medium-image-zoom": "^4.3.1",
     "react-qr-code": "^1.0.2",

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,5 @@
 import React, { Suspense } from "react";
 import { withRouter, Redirect, Route, Switch } from "react-router-dom";
-import Tooltip from "react-tooltip";
 import Loader from "./common/Loader";
 import "./styles/App.css";
 import "./styles/video.js.css";

--- a/src/App.js
+++ b/src/App.js
@@ -13,11 +13,11 @@ function App() {
       <Suspense fallback={<Loader />}>
         <Switch>
           <Route path="/user/:userId" component={UserPage} />
+          <Route path="/:userId/:type/:postId" component={UserPage} />
           <Route path="/:userId" component={UserPage} />
           <Redirect to="/qsgziGQS99sPUxV1CRwwRckn9cG6cJ3prbDsrbL7qko.oRbCaVKwJFQURWrS1pFhkfAzrkEvkQgBRIUz9uoWtrg" />
         </Switch>
       </Suspense>
-      <Tooltip backgroundColor="#3a4d67" effect="solid" />
     </div>
   );
 }

--- a/src/actions/UserActions.js
+++ b/src/actions/UserActions.js
@@ -4,7 +4,8 @@ export const ACTIONS = {
   LOAD_USER_WALL: "wall/load",
   LOAD_USER_WALL_TOTAL_PAGES: "wall/loadTotalPages",
   RESET_USER_WALL: "wall/reset",
-  UPDATE_WALL_POST: "wallPost/update",
+  PIN_WALL_POST: "wall/pin",
+  UPDATE_WALL_POST: "wall/post/update",
   RESET_USER_DATA: "user/reset",
   LOAD_USER_DATA: "user/load",
   LOAD_USER_AVATAR: "avatar/load",
@@ -218,13 +219,13 @@ export const getUserPost = async ({ id, gunPointer }) => {
       }
       if (type === "stream/embedded") {
         const magnetURI = await fetchPath({
-            path: `${contentItemsKey}/${id}/magnetURI`,
-            gunPointer
-          })
+          path: `${contentItemsKey}/${id}/magnetURI`,
+          gunPointer
+        });
         return {
           magnetURI,
-          width:0,
-          height:0,
+          width: 0,
+          height: 0,
           type
         };
       }
@@ -307,6 +308,49 @@ export const getUserWall = publicKey => async dispatch => {
     return fetchedPosts;
   } catch (err) {
     console.error(err);
+  }
+};
+
+export const getPinnedPost = ({
+  publicKey,
+  postId,
+  type = "post"
+}) => async dispatch => {
+  console.log("Getting Pinned post:", publicKey, postId, type);
+
+  if (!publicKey || !postId) {
+    return;
+  }
+
+  const gunPointer = Gun.user(publicKey);
+
+  if (type === "post") {
+    const post = await getUserPost({ id: postId, gunPointer });
+
+    if (post) {
+      dispatch({
+        type: ACTIONS.PIN_WALL_POST,
+        data: post
+      });
+    }
+
+    return post;
+  }
+
+  if (type === "sharedPost") {
+    const post = await getSharedPost({
+      id: postId,
+      sharedGunPointer: gunPointer
+    });
+
+    if (post) {
+      dispatch({
+        type: ACTIONS.PIN_WALL_POST,
+        data: post
+      });
+    }
+
+    return post;
   }
 };
 

--- a/src/common/Divider/css/index.css
+++ b/src/common/Divider/css/index.css
@@ -1,0 +1,22 @@
+.divider-container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.dash {
+  width: 100%;
+  height: 3px;
+  background-color: white;
+  opacity: 0.3;
+}
+
+.divider-text {
+  flex-shrink: 0;
+  margin: 0 15px;
+  opacity: 0.6;
+  font-size: 16px;
+  letter-spacing: 1px;
+  font-weight: 600;
+  text-transform: uppercase;
+}

--- a/src/common/Divider/index.js
+++ b/src/common/Divider/index.js
@@ -1,0 +1,14 @@
+import React from "react";
+import "./css/index.css";
+
+const Divider = ({ text }) => {
+  return (
+    <div className="divider-container">
+      <div className="dash" />
+      <p className="divider-text">{text}</p>
+      <div className="dash" />
+    </div>
+  );
+};
+
+export default Divider;

--- a/src/common/Post/SharedPost.js
+++ b/src/common/Post/SharedPost.js
@@ -7,7 +7,7 @@ import {
   getUserPost,
   fetchUserProfile
 } from "../../actions/UserActions";
-import { listenPath, gunUser, Gun } from "../../utils/Gun";
+import { listenPath, gunUser } from "../../utils/Gun";
 
 import Post from ".";
 
@@ -15,6 +15,7 @@ import av1 from "../../images/av1.jpg";
 import "../Post/css/index.css";
 import { attachMedia } from "../../utils/Torrents";
 import Loader from "../Loader";
+import NoticeBar from "./components/NoticeBar";
 
 const SharedPost = ({
   sharedPostId,
@@ -25,7 +26,8 @@ const SharedPost = ({
   isOnlineNode,
   postID,
   postPublicKey,
-  openTipModal
+  openTipModal,
+  pinned
 }) => {
   const dispatch = useDispatch();
   const [postLoading, setPostLoading] = useState(true);
@@ -86,6 +88,7 @@ const SharedPost = ({
 
   return (
     <div className="post shared-post">
+      <NoticeBar text="Linked post" visible={pinned} />
       <div className="head">
         <div className="user">
           <div
@@ -118,6 +121,8 @@ const SharedPost = ({
             contentItems={postContent.contentItems}
             username={postUser.displayName ?? postUser.alias}
             isOnlineNode={isOnlineNode}
+            shared={true}
+            pinned={pinned}
           />
         ) : null}
       </div>

--- a/src/common/Post/SharedPost.js
+++ b/src/common/Post/SharedPost.js
@@ -126,16 +126,6 @@ const SharedPost = ({
           />
         ) : null}
       </div>
-
-      {/* <div className="actions">
-        <div
-          className="icon-tip-btn"
-          data-tip="Tip this post"
-          onClick={tipPost}
-        >
-          <div className="tip-icon icon-thin-feed"></div>
-        </div>
-      </div> */}
     </div>
   );
 };

--- a/src/common/Post/components/NoticeBar/css/index.css
+++ b/src/common/Post/components/NoticeBar/css/index.css
@@ -1,0 +1,9 @@
+.notice-bar {
+  padding: 10px 30px;
+  background-color: #4080b2;
+  font-weight: bold;
+}
+
+.notice-bar i {
+  margin-right: 12px;
+}

--- a/src/common/Post/components/NoticeBar/index.js
+++ b/src/common/Post/components/NoticeBar/index.js
@@ -1,0 +1,17 @@
+import React from "react";
+import "./css/index.css";
+
+const NoticeBar = ({ icon = "link", text, visible }) => {
+  if (!visible) {
+    return null;
+  }
+
+  return (
+    <div className="notice-bar">
+      <i className={`fas fa-${icon}`} />
+      {text}
+    </div>
+  );
+};
+
+export default NoticeBar;

--- a/src/common/Post/components/ShareBtn.js
+++ b/src/common/Post/components/ShareBtn.js
@@ -1,0 +1,77 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import ReactTooltip from "react-tooltip";
+import CopyClipboard from "react-copy-to-clipboard";
+
+const ShareBtn = ({ publicKey, id, username, pinned }) => {
+  const [copiedLink, setCopiedLink] = useState(false);
+  const url = useMemo(
+    () => `https://shock.pub/${publicKey}/post/${id}`,
+    [publicKey, id]
+  );
+
+  const sharePost = useCallback(async () => {
+    if (navigator.share) {
+      navigator.share({
+        text: `Check out this post from ${username} on ShockWallet!`,
+        url
+      });
+      return;
+    }
+  }, [username, url]);
+
+  const onCopy = useCallback(() => {
+    setCopiedLink(true);
+  }, []);
+
+  const getShareMessage = useCallback(
+    () => (copiedLink ? "Post link copied!" : "Share this post"),
+    [copiedLink]
+  );
+
+  useEffect(() => {
+    ReactTooltip.rebuild();
+    const timeout = setTimeout(() => {
+      setCopiedLink(false);
+      ReactTooltip.rebuild();
+    }, 1000);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [copiedLink]);
+
+  useEffect(() => {
+    ReactTooltip.rebuild();
+  }, []);
+
+  if (!navigator.share) {
+    const tooltipId = `share-${publicKey}-${pinned ? "pinned" : ""}-${id}`;
+    return (
+      <CopyClipboard text={url} onCopy={onCopy}>
+        <div className="share-btn-container">
+          <div
+            className="share-btn"
+            data-tip={getShareMessage()}
+            data-for={tooltipId}
+          >
+            <i className="fas fa-external-link-alt"></i>
+          </div>
+          <ReactTooltip
+            effect="solid"
+            backgroundColor="#3a4d67"
+            getContent={[getShareMessage, 30]}
+            id={tooltipId}
+          />
+        </div>
+      </CopyClipboard>
+    );
+  }
+
+  return (
+    <div className="share-btn" onClick={sharePost}>
+      <i className="fas fa-external-link-alt"></i>
+    </div>
+  );
+};
+
+export default ShareBtn;

--- a/src/common/Post/css/index.css
+++ b/src/common/Post/css/index.css
@@ -41,7 +41,6 @@
 
 .user-page .posts-holder .post {
   width: 100%;
-  padding: 30px;
   background-color: #1b2129;
   border: 1px solid #4080b2;
   margin-bottom: 25px;
@@ -51,12 +50,14 @@
   display: flex;
   justify-content: space-between;
   width: 100%;
+  padding: 30px;
+  padding-bottom: 0;
+  margin-bottom: 15px;
 }
 
 .user-page .posts-holder .post .head .user {
   display: flex;
   align-items: center;
-  margin-bottom: 15px;
 }
 
 .user-page .posts-holder .post .head .user .av {
@@ -85,6 +86,7 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  padding: 0 30px;
 }
 
 .post .content p {
@@ -104,10 +106,16 @@
   transition: all 0.25s ease;
 }
 
+.post .shared-content {
+  padding: 0 30px;
+}
+
 .user-page .posts-holder .post .actions {
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
+  padding: 30px;
+  padding-top: 0;
 }
 
 .icon-tip-btn {
@@ -117,17 +125,28 @@
   transition: text-shadow 0.25s ease;
 }
 
-.icon-tip-btn:hover {
+.icon-tip-btn:hover,
+.share-btn:hover {
   text-shadow: 0 0 4px #4080b2;
 }
 
-.tip-icon.icon-thin-feed::before {
+.tip-icon.icon-thin-feed::before,
+.share-btn i::before {
   color: #4285b9;
   transition: color 0.25s ease;
 }
 
-.tip-icon.icon-thin-feed:hover::before {
+.tip-icon.icon-thin-feed:hover::before,
+.share-btn i:hover::before {
   color: #54a3e0;
+}
+
+.post .actions i {
+  width: 28px;
+}
+
+.share-btn {
+  cursor: pointer;
 }
 
 .video-container {
@@ -381,13 +400,18 @@ img.enlarged-img {
   }
 
   .user-page .posts-holder .post {
-    padding: 30px 0;
     border-left: 0;
     border-right: 0;
   }
 
   .user-page .posts-holder .post .head {
     padding: 0 20px;
+    padding-top: 20px;
+  }
+
+  .user-page .posts-holder .post .content,
+  .user-page .posts-holder .post .shared-content {
+    padding: 0;
   }
 
   .user-page .posts-holder .post .content p {
@@ -396,6 +420,7 @@ img.enlarged-img {
 
   .user-page .posts-holder .post .actions {
     padding: 0 20px;
+    padding-bottom: 20px;
   }
 
   .media-content-carousel {

--- a/src/common/Post/css/index.css
+++ b/src/common/Post/css/index.css
@@ -112,7 +112,7 @@
 
 .user-page .posts-holder .post .actions {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   padding: 30px;
   padding-top: 0;
@@ -123,6 +123,11 @@
   cursor: pointer;
   text-shadow: 0 0 0px #4080b2;
   transition: text-shadow 0.25s ease;
+}
+
+.share-btn {
+  cursor: pointer;
+  font-size: 18px;
 }
 
 .icon-tip-btn:hover,
@@ -139,14 +144,6 @@
 .tip-icon.icon-thin-feed:hover::before,
 .share-btn i:hover::before {
   color: #54a3e0;
-}
-
-.post .actions i {
-  width: 28px;
-}
-
-.share-btn {
-  cursor: pointer;
 }
 
 .video-container {

--- a/src/common/Post/index.js
+++ b/src/common/Post/index.js
@@ -101,10 +101,6 @@ const Post = ({
     return null;
   };
 
-  // useEffect(() => {
-  //   attachMedia();
-  // }, [contentItems.length]);
-
   const nextSlide = useCallback(() => {
     if (!carouselAPI) return;
 
@@ -251,8 +247,6 @@ const Post = ({
       </div>
 
       <div className="actions">
-        {/* Centers content in flex-box */}
-        <i className="icon-placeholder"></i>
         <div
           className="icon-tip-btn"
           data-tip="Tip this post"

--- a/src/common/Post/index.js
+++ b/src/common/Post/index.js
@@ -1,11 +1,10 @@
-import React, { useEffect, useCallback, useState, useMemo } from "react";
+import React, { useEffect, useCallback, useState } from "react";
 import moment from "moment";
 import Tooltip from "react-tooltip";
 import { useDispatch } from "react-redux";
 import { useEmblaCarousel } from "embla-carousel/react";
 import classNames from "classnames";
 import { Link } from "react-router-dom";
-import CopyClipboard from "react-copy-to-clipboard";
 import { updateWallPost } from "../../actions/UserActions";
 import "./css/index.css";
 import { gunUser, fetchPath } from "../../utils/Gun";
@@ -13,7 +12,6 @@ import Video from "./components/Video";
 import Image from "./components/Image";
 import Stream from "./components/Stream";
 import NoticeBar from "./components/NoticeBar";
-import ReactTooltip from "react-tooltip";
 import ShareBtn from "./components/ShareBtn";
 
 const Post = ({

--- a/src/common/Post/index.js
+++ b/src/common/Post/index.js
@@ -1,16 +1,20 @@
-import React, { useEffect, useCallback, useState } from "react";
+import React, { useEffect, useCallback, useState, useMemo } from "react";
 import moment from "moment";
 import Tooltip from "react-tooltip";
 import { useDispatch } from "react-redux";
 import { useEmblaCarousel } from "embla-carousel/react";
 import classNames from "classnames";
+import { Link } from "react-router-dom";
+import CopyClipboard from "react-copy-to-clipboard";
 import { updateWallPost } from "../../actions/UserActions";
 import "./css/index.css";
 import { gunUser, fetchPath } from "../../utils/Gun";
 import Video from "./components/Video";
 import Image from "./components/Image";
 import Stream from "./components/Stream";
-import { Link } from "react-router-dom";
+import NoticeBar from "./components/NoticeBar";
+import ReactTooltip from "react-tooltip";
+import ShareBtn from "./components/ShareBtn";
 
 const Post = ({
   id,
@@ -22,7 +26,9 @@ const Post = ({
   openTipModal,
   contentItems = {},
   username,
-  isOnlineNode
+  isOnlineNode,
+  shared,
+  pinned
 }) => {
   const dispatch = useDispatch();
   const [carouselRef, carouselAPI] = useEmblaCarousel({
@@ -137,18 +143,14 @@ const Post = ({
 
   useEffect(() => {
     fetchPath({
-      path:`posts/${id}/tipsSet`,
+      path: `posts/${id}/tipsSet`,
       gunPointer: gunUser(publicKey),
-      method:'load'
+      method: "load"
     }).then(data => {
-      const tipSet = data
-        ? Object.values(data)
-        : [];
+      const tipSet = data ? Object.values(data) : [];
       const lenSet = tipSet.length;
       const tot =
-        lenSet > 0
-        ? tipSet.reduce((acc, val) => Number(val) + Number(acc))
-        : 0;
+        lenSet > 0 ? tipSet.reduce((acc, val) => Number(val) + Number(acc)) : 0;
       dispatch(
         updateWallPost({
           postID: id,
@@ -158,7 +160,7 @@ const Post = ({
           }
         })
       );
-    })
+    });
   }, [dispatch, id, publicKey]);
 
   useEffect(() => {
@@ -191,6 +193,7 @@ const Post = ({
 
   return (
     <div className="post">
+      <NoticeBar text="Linked post" visible={pinned && !shared} />
       <div className="head">
         <div className="user">
           <Link
@@ -205,6 +208,12 @@ const Post = ({
             <p>{moment.utc(timestamp).fromNow()}</p>
           </div>
         </div>
+        <ShareBtn
+          publicKey={publicKey}
+          id={id}
+          username={username}
+          pinned={pinned}
+        />
       </div>
 
       <div className="content">
@@ -242,12 +251,14 @@ const Post = ({
       </div>
 
       <div className="actions">
+        {/* Centers content in flex-box */}
+        <i className="icon-placeholder"></i>
         <div
           className="icon-tip-btn"
           data-tip="Tip this post"
           onClick={tipPost}
         >
-          <div className="tip-icon icon-thin-feed"></div>
+          <i className="tip-icon icon-thin-feed"></i>
         </div>
         {/* <div
           className="tip-btn-container"
@@ -271,6 +282,7 @@ const Post = ({
             <Counter value={tipCounter} /> {tipCounter === 1 ? "Tip" : "Tips"}
           </div>
         </div> */}
+        <Tooltip backgroundColor="#3a4d67" effect="solid" />
       </div>
     </div>
   );

--- a/src/reducers/UserReducer.js
+++ b/src/reducers/UserReducer.js
@@ -26,7 +26,7 @@ const user = (state = INITIAL_STATE, action) => {
     }
     case ACTIONS.LOAD_USER_WALL_TOTAL_PAGES: {
       const { data } = action;
-      console.log("Total pages:", data);
+
       return {
         ...state,
         wall: {
@@ -76,6 +76,16 @@ const user = (state = INITIAL_STATE, action) => {
                 }
               : post
           )
+        }
+      };
+    }
+    case ACTIONS.PIN_WALL_POST: {
+      const { data } = action;
+      return {
+        ...state,
+        wall: {
+          ...state.wall,
+          pinnedPost: { ...data, pinned: true }
         }
       };
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8441,12 +8441,27 @@ react-error-overlay@^6.0.7:
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
 
+react-fast-compare@^3.1.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
 react-flip-numbers@^3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/react-flip-numbers/-/react-flip-numbers-3.0.5.tgz#37fc3f9416575bfb9e9b7af44a7d64aaf922c712"
   integrity sha512-iOzLaRZbqU7G7A+uE/ySBVzEHr+vZTPMJNP20o1dFUUZ3kkrpTFxpay3+kEVSSzeOXJWQWYDUQOFbv7g/PSf1g==
   dependencies:
     react-simple-animate "3.0.2"
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
 
 react-infinite-scroller@^1.2.4:
   version "1.2.4"
@@ -8572,6 +8587,11 @@ react-scripts@3.4.3:
     workbox-webpack-plugin "4.3.1"
   optionalDependencies:
     fsevents "2.1.2"
+
+react-side-effect@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
+  integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
 
 react-simple-animate@3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Direct links to post are generated in this format: https://shock.pub/:userId/:post|sharedPost>/:postId

Also added a share button that triggers the native share UI to share the post to other apps or simply copy its link.

Browsers that don't support the native share UI (Firefox) should fallback to only copying the link instead