### PR TITLE
Async GunDB fetching for Posts and User info

### DIFF
--- a/src/common/Post/SharedPost.js
+++ b/src/common/Post/SharedPost.js
@@ -4,8 +4,8 @@ import Tooltip from "react-tooltip";
 import { useDispatch } from "react-redux";
 import {
   updateWallPost,
-  getUserPost,
-  fetchUserProfile
+  getUserWallPostContent,
+  getUserWallPostInfo
 } from "../../actions/UserActions";
 import { listenPath, gunUser } from "../../utils/Gun";
 
@@ -64,21 +64,28 @@ const SharedPost = ({
     });
   }, [dispatch, sharedPostId, sharerPublicKey]);
 
-  const loadPost = useCallback(async () => {
-    setPostLoading(true);
-    if (!postPublicKey) return;
-    const [userProfile, userPost] = await Promise.all([
-      fetchUserProfile({ publicKey: postPublicKey, includeAvatar: true }),
-      getUserPost({
-        id: postID,
-        gunPointer: gunUser(postPublicKey)
-      })
-    ]);
-    setPostUser(userProfile);
+  const loadPostUser = useCallback(async () => {
+    const userInfo = await dispatch(
+      getUserWallPostInfo({ publicKey: postPublicKey, id: postID })
+    );
+    setPostUser(userInfo);
+  }, [dispatch, postID, postPublicKey]);
+
+  const loadPostContent = useCallback(async () => {
+    const userPost = await dispatch(
+      getUserWallPostContent({ publicKey: postPublicKey, id: postID })
+    );
     setPostContent(userPost);
     setPostLoading(false);
     attachMedia([userPost], false);
-  }, [postID, postPublicKey]);
+  }, [dispatch, postID, postPublicKey]);
+
+  const loadPost = useCallback(async () => {
+    setPostLoading(true);
+    if (!postPublicKey) return;
+    loadPostUser();
+    loadPostContent();
+  }, [loadPostContent, loadPostUser, postPublicKey]);
 
   useEffect(() => {
     Tooltip.rebuild();

--- a/src/reducers/UserReducer.js
+++ b/src/reducers/UserReducer.js
@@ -12,21 +12,22 @@ const INITIAL_STATE = {
 };
 
 const user = (state = INITIAL_STATE, action) => {
+  const { data } = action;
+
   switch (action.type) {
     case ACTIONS.LOAD_USER_WALL: {
-      const { data } = action;
       return {
         ...state,
         wall: {
           ...state.wall,
-          posts: [...state.wall.posts, ...data.posts],
+          posts: [...state.wall.posts, ...data.posts].sort(
+            (a, b) => b.date - a.date
+          ),
           page: data.page
         }
       };
     }
     case ACTIONS.LOAD_USER_WALL_TOTAL_PAGES: {
-      const { data } = action;
-
       return {
         ...state,
         wall: {
@@ -35,15 +36,74 @@ const user = (state = INITIAL_STATE, action) => {
         }
       };
     }
+    case ACTIONS.LOAD_WALL_POST_CONTENT_LENGTH: {
+      return {
+        ...state,
+        wall: {
+          ...state.wall,
+          posts: state.wall.posts?.map(post =>
+            data.id === post.id
+              ? {
+                  ...post,
+                  contentItems: Array.from({ length: data.length })
+                }
+              : post
+          )
+        }
+      };
+    }
+    case ACTIONS.LOAD_WALL_POST_INFO: {
+      const loadedPosts = state.wall.posts?.map(post =>
+        data.id === post.id
+          ? {
+              ...post,
+              ...data.postInfo,
+              contentItems: post.contentItems ?? []
+            }
+          : post
+      );
+      const sortedPosts = loadedPosts.sort((a, b) => b.date - a.date);
+      return {
+        ...state,
+        wall: {
+          ...state.wall,
+          posts: sortedPosts
+        }
+      };
+    }
+    case ACTIONS.LOAD_WALL_POST_CONTENT: {
+      return {
+        ...state,
+        wall: {
+          ...state.wall,
+          posts: state.wall.posts?.map(post => {
+            const matched = data.id === post.id;
+
+            console.log({ post, data });
+
+            if (!matched) {
+              return post;
+            }
+
+            return {
+              ...post,
+              contentItems: post.contentItems?.map((item, key) =>
+                data.key === key
+                  ? { ...(item ?? {}), ...(data.contentItem ?? {}) }
+                  : item
+              )
+            };
+          })
+        }
+      };
+    }
     case ACTIONS.LOAD_USER_DATA: {
-      const { data } = action;
       return {
         ...state,
         profile: data
       };
     }
     case ACTIONS.LOAD_USER_AVATAR: {
-      const { data } = action;
       return {
         ...state,
         profile: {
@@ -53,7 +113,6 @@ const user = (state = INITIAL_STATE, action) => {
       };
     }
     case ACTIONS.UPDATE_USER_PROFILE: {
-      const { data } = action;
       return {
         ...state,
         profile: {
@@ -80,7 +139,6 @@ const user = (state = INITIAL_STATE, action) => {
       };
     }
     case ACTIONS.PIN_WALL_POST: {
-      const { data } = action;
       return {
         ...state,
         wall: {

--- a/src/utils/Gun.js
+++ b/src/utils/Gun.js
@@ -2,7 +2,7 @@ import GunDB from "gun/gun";
 import "gun/sea";
 import { isCrawler } from "./Prerender";
 
-const safeParse = (data) => {
+const safeParse = data => {
   try {
     return JSON.parse(data);
   } catch (err) {
@@ -16,14 +16,14 @@ const peers = peersConfig
   ? peersConfig
   : ["https://gun.shock.network/gun", "https://gun-eu.shock.network/gun"];
 
-const wait = (ms) =>
+const wait = ms =>
   new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve(true);
     }, ms);
   });
 
-const _randomString = (length) => {
+const _randomString = length => {
   let randomString = "";
   const randomChar = function () {
     const n = Math.floor(Math.random() * 62);
@@ -37,7 +37,7 @@ const _randomString = (length) => {
 
 const _filterGunProps = ([key, item]) => item && key !== "_" && key !== "#";
 
-const _isIncompleteGunResponse = (data) => {
+const _isIncompleteGunResponse = data => {
   try {
     console.log("Incomplete Gun Response Check:", typeof data, data);
     if (data === null || data === undefined) {
@@ -98,22 +98,22 @@ const parseGunPath = ({ path, gunPointer = Gun }) => {
   return node;
 };
 
-export const Gun = GunDB({ axe: false, peers: peers });
+export const Gun = GunDB({ peers: peers });
 
 window.gun = Gun;
 
 export const fetchPath = ({
   path = "",
-  retryDelay = 250,
-  retryLimit = 1,
+  retryDelay = 500,
+  retryLimit = 3,
   retryCondition = _isIncompleteGunResponse,
   gunPointer = Gun,
   method = "once",
 
   _retryCount = 0,
-  _fallbackResult,
+  _fallbackResult
 }) =>
-  new Promise((resolve) => {
+  new Promise(resolve => {
     const parsedRetryLimit = isCrawler() ? 1 : retryLimit;
     const parsedRetryDelay = isCrawler() ? 200 : retryDelay;
 
@@ -121,6 +121,7 @@ export const fetchPath = ({
       resolve(_fallbackResult);
       return;
     }
+
     if (_retryCount > 0) {
       console.log(
         "Retrying event:",
@@ -131,7 +132,7 @@ export const fetchPath = ({
     const GunContext = parseGunPath({ path, gunPointer });
     console.log("Fetching Path:", path, GunContext);
 
-    GunContext[method](async (event) => {
+    GunContext[method](async event => {
       console.log(path + " Response:", event);
       if (retryCondition && retryCondition(event)) {
         await wait(parsedRetryDelay);
@@ -143,7 +144,7 @@ export const fetchPath = ({
           gunPointer,
 
           _retryCount: _retryCount + 1,
-          _fallbackResult: event,
+          _fallbackResult: event
         });
         resolve(retryResult);
         return;
@@ -154,7 +155,7 @@ export const fetchPath = ({
   });
 
 // Wraps GunDB data callbacks to provide better error handling
-export const wrap = (callback) => (event) => {
+export const wrap = callback => event => {
   console.log("Event received!", event);
   if (event?.err) {
     console.error("[GunDB] Event error:", event?.err, event);
@@ -174,7 +175,7 @@ export const wrap = (callback) => (event) => {
             : !event.put
             ? "Key not found"
             : "Unknown",
-          gunErr: event.err,
+          gunErr: event.err
         }
       : null
   );
@@ -199,7 +200,7 @@ export const putPath = ({ path = "", data = {}, gunPointer = Gun }) =>
 export const setPath = ({ path = "", data = {}, gunPointer = Gun }) =>
   new Promise((resolve, reject) => {
     const GunContext = parseGunPath({ path, gunPointer });
-    const response = GunContext.set(data, (event) => {
+    const response = GunContext.set(data, event => {
       console.log(data);
       resolve(response);
     });
@@ -207,7 +208,7 @@ export const setPath = ({ path = "", data = {}, gunPointer = Gun }) =>
 
 export const listenPath = ({ path = "", gunPointer = Gun, callback }) => {
   const GunContext = parseGunPath({ path, gunPointer });
-  return GunContext.on((event) => {
+  return GunContext.on(event => {
     callback(event);
   });
 };
@@ -216,14 +217,14 @@ export const createRandomGunUser = () =>
   new Promise((resolve, reject) => {
     const randomAlias = _randomString(10);
     const randomPass = _randomString(10);
-    Gun.user().create(randomAlias, randomPass, (event) => {
+    Gun.user().create(randomAlias, randomPass, event => {
       if (event.err) {
         console.error("An error has occurred while initializing a new user");
         reject({
           field: "gundb",
           message: "An error has occurred while initializing a new user",
           _error: event.err,
-          _event: event,
+          _event: event
         });
         return;
       }
@@ -233,12 +234,12 @@ export const createRandomGunUser = () =>
 
 export const authUser = (alias, pass) =>
   new Promise((resolve, reject) => {
-    Gun.user().auth(alias, pass, (user) => {
+    Gun.user().auth(alias, pass, user => {
       resolve(user);
     });
   });
 
-export const gunUser = (publicKey) => {
+export const gunUser = publicKey => {
   console.log("Getting Gun User:", publicKey);
   if (!publicKey) {
     throw new Error("Undefined public key");


### PR DESCRIPTION
GunDB fetches should no longer rely on each other before rendering the posts, before this change, the site used to fetch the user's info (avatar, name, etc...) and once it fetches those successfully, it moves over to fetching posts and shared posts along with each one of the post's media as well. In case one of those fetches fails, the entire Posts tab either renders empty or gets stuck on the "Loading Posts..." indicator.

Now since all of the post queries are asynchronous, I've also increased the retry-limit and retry-delay since if one of the queries fails, the retry delay shouldn't slow down the site at all while at the same time ensuring that we get the right response from GunDB 😄 